### PR TITLE
chore(deps): bump follow-redirects

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4142,9 +4142,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Description
This PR merges a dependabot security update for `follow-redirects` from 1.15.11 to 1.16.0 in `/frontend`.

Bumps the npm_and_yarn group with 1 update in the /frontend directory: [follow-redirects](https://github.com/follow-redirects/follow-redirects).

Updates `follow-redirects` from 1.15.11 to 1.16.0
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.11...v1.16.0)

---
updated-dependencies:
- dependency-name: follow-redirects dependency-version: 1.16.0 dependency-type: indirect dependency-group: npm_and_yarn ...


(cherry picked from commit a27411f65f7f104d670e6a833b8d7bee9d898290)
